### PR TITLE
AzSearch e Loading

### DIFF
--- a/src/components/search/AzSearch.vue
+++ b/src/components/search/AzSearch.vue
@@ -2,7 +2,7 @@
     <div class="az-search">
         <div class="simple-search" >
             <div class="input-search" :style="inputSearchStyle">
-                <v-tooltip top v-for="(val, key) in filter" v-if="val.value">
+                <v-tooltip top v-for="(val, key) in filter" :key="val.value" v-if="val.value">
                     <v-chip close @input="removeFilter(key)" slot="activator">
                         <strong>{{val.label}}:</strong>&nbsp;
                         <span>{{val.valueTruncated ? val.valueTruncated : val.value}}</span>

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -52,6 +52,8 @@ export default {
     [mutationTypes.SET_GLOBAL_LOADING](state, loading) {
         if (state.isGlobalLoadingEnabled) {
             state.isLoading = loading
+        } else if (!loading) {
+            state.isLoading = loading
         }
     },
 


### PR DESCRIPTION
- Correção do warning emitido pelo v-for sem o atributo key correspondente no AzSearch

- Ajustei a mutation SET_GLOBAL_LOADING para aceitar o valor "false" mesmo se o loading global estiver desabilitado