### PR TITLE
Bugfix v0.4.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
         }
       }
     ]
-
   },
   "prettier": {
     "printWidth": 120,

--- a/src/components/layout/AzAlert.vue
+++ b/src/components/layout/AzAlert.vue
@@ -17,16 +17,18 @@ export default {
             show: false
         }
     },
-    created: function () {
-        this.$store.watch(state => state.loki.alert, () => {
-            const alert = this.$store.state.loki.alert
-            if (alert.message !== '') {
-                this.show = true
-                this.text = alert.message
-                this.color = alert.type
+    created: function() {
+        this.$store.watch(
+            state => state.loki.alert,
+            () => {
+                const alert = this.$store.state.loki.alert
+                if (alert.message !== '') {
+                    this.show = true
+                    this.text = alert.message
+                    this.color = alert.type
+                }
             }
-        }
+        )
     }
-}
 }
 </script>

--- a/src/components/layout/AzTitle.vue
+++ b/src/components/layout/AzTitle.vue
@@ -1,7 +1,7 @@
 <template>
     <v-toolbar-title class="az-title">
         <span class="az-title__title primary--text">{{ title }}</span>
-        <span class="az-title__subtitle">» {{ subtitle }}</span>
+        <span class="az-title__subtitle" v-if="subtitle">» {{ subtitle }}</span>
     </v-toolbar-title>
 </template>
 <script>

--- a/src/components/viewer/AzPdfDocumentViewer.vue
+++ b/src/components/viewer/AzPdfDocumentViewer.vue
@@ -72,13 +72,12 @@ export default {
         }
     },
     async created() {
+        this.$store.dispatch(actionTypes.DOCUMENT.UPDATE_CURRENT_PAGE_NUM, this.visiblePageNum)
+        this.$store.dispatch(actionTypes.DOCUMENT.CLEAR_RENDERED_PAGES)
         await this.$store.dispatch(actionTypes.DOCUMENT.FETCH_DOCUMENT, this.$props.src)
     },
     mounted() {
         this.getDocumentContainer().addEventListener('scroll', this.handleScroll)
-    },
-    destroyed() {
-        this.getDocumentContainer().removeEventListener('scroll', this.handleScroll)
     },
     methods: {
         getDocumentContainer() {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -39,6 +39,7 @@ export default {
         let pdf = await pdfjs.fetchDocument(src)
         context.commit(mutationTypes.DOCUMENT.SET_TOTAL_PAGE_NUM, pdf.numPages)
         context.commit(mutationTypes.DOCUMENT.SET_PAGES, await pdfjs.getPages(pdf))
+        context.commit(mutationTypes.DOCUMENT.SET_CURRENT_SCALE, 1.5)
         context.dispatch(actionTypes.DOCUMENT.UPDATE_PAGE_CONTAINER)
     },
 


### PR DESCRIPTION
#### AzAlert.vue

inserido ')' na função created, remoção provavelmente causado pelo lint.

#### AzPdfDocumentViewer.vue

removido método destroyed() que estava causando log de erro

adicionado no método created() actions para limpar a lista de páginas renderizadas e atualizar a página atual para 1

#### actions.js

adicionado no método FETCH_DOCUMENT um commit para re-setar a escala quando um novo documento é carregado

#### AzTitle.vue

validação para exibir o subtitle se existir o mesmo.