### PR TITLE
[Bugfix] AzPdfDocumentViewer

### DIFF
--- a/src/components/viewer/AzPdfDocumentViewer.spec.js
+++ b/src/components/viewer/AzPdfDocumentViewer.spec.js
@@ -1,70 +1,70 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import Vuex from 'vuex'
+import 'pdfjs-dist/build/pdf'
 import AzPdfDocumentViewer from './AzPdfDocumentViewer'
 import AzPdfDocumentViewerToolbar from './AzPdfDocumentViewerToolbar'
 import AzPdfDocumentViewerPage from './AzPdfDocumentViewerPage'
 import { actionTypes } from '../../../src/store'
 import { createLocalVue, shallowMount } from '@vue/test-utils'
 
+jest.mock('pdfjs-dist/build/pdf')
 const localVue = createLocalVue()
 Vue.use(Vuetify)
 Vue.use(Vuex)
 
 describe('AzPdfDocumentViewer.spec.js', () => {
-    let src, wrapper, store, state, getters, actions, documentContainer
-
-    state = {
-        document: {
-            pageContainer: {
-                height: 1,
-                width: 1
-            },
-            pages: [{ pageIndex: 0 }, { pageIndex: 1 }, { pageIndex: 2 }],
-            paginator: {
-                currentPageNum: 1,
-                totalPageNum: 1
-            },
-            scale: {
-                current: 1.0,
-                default: 1.0,
-                max: 3.0
-            },
-            renderedPages: []
-        }
-    }
-
-    getters = {
-        currentPageNum: jest.fn().mockReturnValue(1),
-        pageContainer: jest.fn().mockReturnValue({ height: 1, width: 1 }),
-        pages: jest.fn().mockReturnValue(state.document.pages),
-        scale: jest.fn().mockReturnValue(1),
-        totalPageNum: jest.fn().mockReturnValue(3)
-    }
-
-    actions = {
-        [actionTypes.DOCUMENT.FETCH_DOCUMENT]: jest.fn(),
-        [actionTypes.DOCUMENT.UPDATE_PAGE_CONTAINER]: jest.fn(),
-        [actionTypes.DOCUMENT.UPDATE_CURRENT_PAGE_NUM]: jest.fn(),
-        [actionTypes.DOCUMENT.DECREASE_SCALE]: jest.fn(),
-        [actionTypes.DOCUMENT.INCREASE_SCALE]: jest.fn(),
-        [actionTypes.DOCUMENT.RESTORE_SCALE]: jest.fn(),
-        [actionTypes.DOCUMENT.RENDER_PAGE]: jest.fn(),
-        [actionTypes.DOCUMENT.CLEAR_RENDERED_PAGES]: jest.fn(),
-        [actionTypes.DOCUMENT.UPDATE_RENDERED_PAGES]: jest.fn()
-    }
-
-    documentContainer = document.createElement('div')
-    documentContainer.setAttribute('id', 'documentContainer')
+    let src, wrapper, store, state, getters, actions
 
     beforeEach(() => {
+        state = {
+            document: {
+                pageContainer: {
+                    height: 1,
+                    width: 1
+                },
+                pages: [{ pageIndex: 0 }, { pageIndex: 1 }, { pageIndex: 2 }],
+                paginator: {
+                    currentPageNum: 1,
+                    totalPageNum: 1
+                },
+                scale: {
+                    current: 1.0,
+                    default: 1.0,
+                    max: 3.0
+                },
+                renderedPages: []
+            }
+        }
+
+        getters = {
+            currentPageNum: jest.fn().mockReturnValue(1),
+            pageContainer: jest.fn().mockReturnValue({ height: 1, width: 1 }),
+            pages: jest.fn().mockReturnValue(state.document.pages),
+            scale: jest.fn().mockReturnValue(1),
+            totalPageNum: jest.fn().mockReturnValue(3)
+        }
+
+        actions = {
+            [actionTypes.DOCUMENT.FETCH_DOCUMENT]: jest.fn(),
+            [actionTypes.DOCUMENT.UPDATE_PAGE_CONTAINER]: jest.fn(),
+            [actionTypes.DOCUMENT.UPDATE_CURRENT_PAGE_NUM]: jest.fn(),
+            [actionTypes.DOCUMENT.DECREASE_SCALE]: jest.fn(),
+            [actionTypes.DOCUMENT.INCREASE_SCALE]: jest.fn(),
+            [actionTypes.DOCUMENT.RESTORE_SCALE]: jest.fn(),
+            [actionTypes.DOCUMENT.RENDER_PAGE]: jest.fn(),
+            [actionTypes.DOCUMENT.CLEAR_RENDER_CONTEXT]: jest.fn(),
+            [actionTypes.DOCUMENT.CLEAR_RENDERED_PAGES]: jest.fn(),
+            [actionTypes.DOCUMENT.UPDATE_RENDERED_PAGES]: jest.fn()
+        }
+
         store = new Vuex.Store({ state, getters, actions })
         src = 'document/url'
-        document.body.appendChild(documentContainer)
         wrapper = shallowMount(AzPdfDocumentViewer, {
             localVue,
             store,
-            propsData: { src }
+            propsData: { src },
+            attachToDocument: true
         })
     })
 
@@ -95,12 +95,11 @@ describe('AzPdfDocumentViewer.spec.js', () => {
     })
 
     describe('Vue Lifecycle', () => {
-        it('Should load the document and update pages size in the mounted method', async () => {
+        it('Should clear render context and load the document the mounted method', async () => {
             await wrapper.vm.$nextTick()
 
-            expect(actions[actionTypes.DOCUMENT.UPDATE_CURRENT_PAGE_NUM].mock.calls[0][1]).toEqual(1)
+            expect(actions[actionTypes.DOCUMENT.CLEAR_RENDER_CONTEXT]).toHaveBeenCalled()
             expect(actions[actionTypes.DOCUMENT.FETCH_DOCUMENT].mock.calls[0][1]).toEqual(src)
-            expect(actions[actionTypes.DOCUMENT.CLEAR_RENDERED_PAGES]).toHaveBeenCalled()
         })
 
         it('Should have a mounted method', () => {
@@ -215,7 +214,7 @@ describe('AzPdfDocumentViewer.spec.js', () => {
 
             wrapper.vm.$nextTick(() => {
                 expect(actions[actionTypes.DOCUMENT.UPDATE_CURRENT_PAGE_NUM]).toHaveBeenCalled()
-                expect(actions[actionTypes.DOCUMENT.UPDATE_CURRENT_PAGE_NUM].mock.calls[0][1]).toBe(1)
+                expect(actions[actionTypes.DOCUMENT.UPDATE_CURRENT_PAGE_NUM].mock.calls[0][1]).toBe(11)
             })
         })
     })

--- a/src/components/viewer/AzPdfDocumentViewer.vue
+++ b/src/components/viewer/AzPdfDocumentViewer.vue
@@ -39,7 +39,7 @@ export default {
         },
         height: {
             type: String,
-            default: '100hv'
+            default: '100vh'
         }
     },
     data: () => ({

--- a/src/components/viewer/AzPdfDocumentViewer.vue
+++ b/src/components/viewer/AzPdfDocumentViewer.vue
@@ -21,7 +21,7 @@
 <script>
 import AzPdfDocumentViewerToolbar from './AzPdfDocumentViewerToolbar'
 import AzPdfDocumentViewerPage from './AzPdfDocumentViewerPage'
-import { actionTypes } from '../../store'
+import { actionTypes, mutationTypes } from '../../store'
 export default {
     components: {
         AzPdfDocumentViewerToolbar,
@@ -48,6 +48,9 @@ export default {
         visiblePageNum: 1
     }),
     computed: {
+        computedSrc() {
+            return this.src
+        },
         currentPage() {
             return this.$store.getters.currentPageNum
         },
@@ -73,9 +76,6 @@ export default {
         },
         totalPages() {
             return this.$store.getters.totalPageNum
-        },
-        updateSrc() {
-            return this.src
         }
     },
     async mounted() {
@@ -84,10 +84,17 @@ export default {
     },
     methods: {
         async updatePdfRendering() {
-            if (this.updateSrc) {
-                this.$store.dispatch(actionTypes.DOCUMENT.UPDATE_CURRENT_PAGE_NUM, this.visiblePageNum)
-                this.$store.dispatch(actionTypes.DOCUMENT.CLEAR_RENDERED_PAGES)
-                await this.$store.dispatch(actionTypes.DOCUMENT.FETCH_DOCUMENT, this.updateSrc)
+            try {
+                this.$store.dispatch(actionTypes.DOCUMENT.CLEAR_RENDER_CONTEXT)
+                await this.$store.dispatch(actionTypes.DOCUMENT.FETCH_DOCUMENT, this.computedSrc)
+            } catch (error) {
+                if (this.computedSrc.length !== 0) {
+                    this.$store.commit(mutationTypes.SHOW_ALERT, {
+                        message: 'URL do documento inválida.',
+                        type: 'error'
+                    })
+                    throw new Error('URL do documento inválida.')
+                }
             }
         },
         getDocumentContainer() {
@@ -96,7 +103,7 @@ export default {
         async handleScroll(e) {
             this.visiblePageNum = Math.floor(e.target.scrollTop / this.pageHeight) + 1
             this.$store.dispatch(actionTypes.DOCUMENT.UPDATE_CURRENT_PAGE_NUM, this.visiblePageNum)
-            if (this.renderedPages.indexOf(this.visiblePageNum) === -1) {
+            if (!isNaN(this.visiblePageNum) && this.renderedPages.indexOf(this.visiblePageNum) === -1) {
                 this.okToRender = true
                 this.$store.dispatch(actionTypes.DOCUMENT.UPDATE_RENDERED_PAGES, this.visiblePageNum)
             }
@@ -132,7 +139,7 @@ export default {
         }
     },
     watch: {
-        async updateSrc() {
+        async computedSrc() {
             await this.updatePdfRendering()
         }
     }

--- a/src/components/viewer/AzPdfDocumentViewer.vue
+++ b/src/components/viewer/AzPdfDocumentViewer.vue
@@ -130,6 +130,7 @@ export default {
         async resolveEventResize(payload) {
             this.pagesCanvasContext[payload.pageNum] = payload
             if (payload.pageNum === this.visiblePageNum) {
+                this.$store.dispatch(actionTypes.DOCUMENT.UPDATE_CURRENT_PAGE_NUM, this.visiblePageNum)
                 await this.$store.dispatch(
                     actionTypes.DOCUMENT.RENDER_PAGE,
                     this.pagesCanvasContext[this.visiblePageNum]

--- a/src/components/viewer/AzPdfDocumentViewerToolbar.vue
+++ b/src/components/viewer/AzPdfDocumentViewerToolbar.vue
@@ -1,13 +1,13 @@
 <template>
     <v-toolbar class="az-pdf-toolbar" flat>
         <v-spacer />
-        <v-btn @click="zoomOut" icon data-test="zoomOut" :disabled="totalPages === 0">
+        <v-btn @click="zoomOut" icon data-test="zoomOut" :disabled="disableButtons">
             <v-icon>zoom_out</v-icon>
         </v-btn>
-        <v-btn @click="resetZoom" icon data-test="resetZoom" :disabled="totalPages === 0">
+        <v-btn @click="resetZoom" icon data-test="resetZoom" :disabled="disableButtons">
             <v-icon>aspect_ratio</v-icon>
         </v-btn>
-        <v-btn @click="zoomIn" icon data-test="zoomIn" :disabled="totalPages === 0">
+        <v-btn @click="zoomIn" icon data-test="zoomIn" :disabled="disableButtons">
             <v-icon>zoom_in</v-icon>
         </v-btn>
         <div class="az-pdf-toolbar__page-viewer">{{ currentPage }} / {{ totalPages }}</div>
@@ -19,12 +19,15 @@
 export default {
     props: {
         currentPage: {
-            type: Number,
             required: true
         },
         totalPages: {
-            type: Number,
             required: true
+        }
+    },
+    computed: {
+        disableButtons() {
+            return this.totalPages === '-'
         }
     },
     methods: {

--- a/src/store/action-types.js
+++ b/src/store/action-types.js
@@ -1,5 +1,6 @@
 export default {
     DOCUMENT: {
+        CLEAR_RENDER_CONTEXT: 'clearRenderContex',
         CLEAR_RENDERED_PAGES: 'clearRenderedPages',
         DECREASE_SCALE: 'decreaseScale',
         FETCH_DOCUMENT: 'fetchDocument',

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -86,6 +86,15 @@ export default {
         context.commit(mutationTypes.DOCUMENT.SET_RENDERED_PAGES, pageNum)
     },
 
+    [actionTypes.DOCUMENT.CLEAR_RENDER_CONTEXT](context) {
+        context.commit(mutationTypes.DOCUMENT.SET_PAGES, [])
+        context.commit(mutationTypes.DOCUMENT.SET_RENDERED_PAGES, 'clear')
+        context.commit(mutationTypes.DOCUMENT.SET_TOTAL_PAGE_NUM, 1)
+        context.commit(mutationTypes.DOCUMENT.SET_CURRENT_PAGE_NUM, 1)
+        context.commit(mutationTypes.DOCUMENT.SET_CURRENT_SCALE, 1.5)
+        context.commit(mutationTypes.DOCUMENT.SET_PAGE_CONTAINER, { height: 0, width: 0 })
+    },
+
     [actionTypes.DOCUMENT.CLEAR_RENDERED_PAGES](context) {
         context.commit(mutationTypes.DOCUMENT.SET_RENDERED_PAGES, 'clear')
     }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -89,8 +89,8 @@ export default {
     [actionTypes.DOCUMENT.CLEAR_RENDER_CONTEXT](context) {
         context.commit(mutationTypes.DOCUMENT.SET_PAGES, [])
         context.commit(mutationTypes.DOCUMENT.SET_RENDERED_PAGES, 'clear')
-        context.commit(mutationTypes.DOCUMENT.SET_TOTAL_PAGE_NUM, 1)
-        context.commit(mutationTypes.DOCUMENT.SET_CURRENT_PAGE_NUM, 1)
+        context.commit(mutationTypes.DOCUMENT.SET_TOTAL_PAGE_NUM, '-')
+        context.commit(mutationTypes.DOCUMENT.SET_CURRENT_PAGE_NUM, '-')
         context.commit(mutationTypes.DOCUMENT.SET_CURRENT_SCALE, 1.5)
         context.commit(mutationTypes.DOCUMENT.SET_PAGE_CONTAINER, { height: 0, width: 0 })
     },

--- a/src/store/state.js
+++ b/src/store/state.js
@@ -58,8 +58,8 @@ export default {
         },
         pages: [],
         paginator: {
-            currentPageNum: 0,
-            totalPageNum: 0
+            currentPageNum: '-',
+            totalPageNum: '-'
         },
         renderedPages: [],
         scale: {


### PR DESCRIPTION
### correções realizadas

Ao visualizar vários documentos seguidos algumas páginas do documento anterior permaneciam renderizados.

A props ```src``` do componente pode ser uma ```String``` vazia, onde irá carregar o componente porém sem pdf a ser exibido. Isso desabilita os botões de zoom e a paginação é identificada como ```- / -```.

Quando a props ```src``` é inválida o componente irá lançar um erro e setar um alerta de erro através do ```SHOW_ALERT```.
