### PR TITLE
Alterações no AzMoney e AzDate

### DIFF
--- a/src/components/form/AzDate.vue
+++ b/src/components/form/AzDate.vue
@@ -66,7 +66,7 @@
                     v-if="dialogTime"
                     v-model="time"
                     :locale="currentLanguage"
-                    @change="updateModelTime($event)"
+                    @change="changeTimeEvent(), updateModelTime($event)"
                     format="24hr"
                     class="az-date"/>
             </v-dialog>

--- a/src/components/form/AzDate.vue
+++ b/src/components/form/AzDate.vue
@@ -16,7 +16,7 @@
                     v-model="date"
                     :value="value"
                     :locale="currentLanguage"
-                    @input="pickDateEvent(), updateModelDate($event)"
+                    @input="updateModelDate($event)"
                     :min="minDate"
                     :max="maxDate"
                     class="az-date"/>
@@ -34,8 +34,8 @@
                 :max-date="maxDate"
                 append-icon="event"
                 @click:append="openMenuDate"
-                @keyup="validateAndParseDate(dateFormatted)"
-                @blur="validateAndParseDate(dateFormatted)">
+                @keyup="validateAndParseDate(dateFormatted, false)"
+                @blur="validateAndParseDate(dateFormatted, true)">
                 <template v-slot:label v-if="this.$slots['label-date']">
                     <slot name="label-date" />
                 </template>
@@ -66,7 +66,7 @@
                     v-if="dialogTime"
                     v-model="time"
                     :locale="currentLanguage"
-                    @change="changeTimeEvent(), updateModelTime($event)"
+                    @change="updateModelTime($event)"
                     format="24hr"
                     class="az-date"/>
             </v-dialog>
@@ -208,12 +208,11 @@ export default {
             this.dialogDate = false
             this.dateFormatted = this.formatDate(this.date)
         },
-        validateAndParseDate(date) {
+        validateAndParseDate(date, clearInvalid) {
             if (!date || !this.dateStringIsValid(date) || this.dateMaxIsAllowed(date) || this.dateMinIsAllowed(date)) {
-                if(date.length == 0) {
+                if(clearInvalid) {
                     this.date = null
                     this.dateFormatted = ''
-                    this.$emit('input', null)
                 }
                 return
             }

--- a/src/components/form/AzMoney.vue
+++ b/src/components/form/AzMoney.vue
@@ -116,6 +116,11 @@ export default {
             return this.value !== null && this.showClearButton ? 'fas fa-times-circle' : ''
         }
     },
+    updated:function(){
+        if(!this.required){
+            this.clearErrorValidate()
+        }
+    },
     methods: {
         updateValue(value, event) {
             let valueNumber = value

--- a/src/components/form/AzMoney.vue
+++ b/src/components/form/AzMoney.vue
@@ -116,7 +116,7 @@ export default {
             return this.value !== null && this.showClearButton ? 'fas fa-times-circle' : ''
         }
     },
-    updated:function(){
+    updated(){
         if(!this.required){
             this.clearErrorValidate()
         }


### PR DESCRIPTION
Bom Dia, fiz algumas alterações nos componentes AzMoney e AzDate. 

AzDate: 
remoção: pickDateEvent()
justificativa: Eu decidi remover essa chamada de método pois percebi que existia uma duplicidade na hora de salvar a data. Por conta disso ele mandava duas vezes o mesmo valor, no caso a data, e por conta disso. Cadastrava dois registro no banco onde o mesmo estava setado para uniq. 

AzMoney:
Acréscimo: Eu coloquei um updated para verificar toda vez que o required do componente fosse mudado, pois ele só ativa a validação quando o metodo blur é chamado e por conta disso muita das vezes o validateAll() no componente pai, não reconhecia o erro do azMoney