### PR TITLE
Added rule to set date null and dateFormatted to empty string when date is before min date or after max date

### DIFF
--- a/src/components/form/AzDate.vue
+++ b/src/components/form/AzDate.vue
@@ -237,13 +237,15 @@ export default {
         },
         validateAndParseDate(date) {
             if (!date || !this.dateStringIsValid(date) || this.dateMaxIsAllowed(date) || this.dateMinIsAllowed(date)) {
+                if ((date && this.dateStringIsValid(date)) && (this.dateMaxIsAllowed(date) || this.dateMinIsAllowed(date))) {
+                    this.date = null
+                    this.dateFormatted = ''
+                    return
+                }
                 if(date === null || date.length === 0) {
                     this.date = null
                     this.dateFormatted = ''
                     this.$emit('input', null)
-                } else if (this.dateMaxIsAllowed(date) || this.dateMinIsAllowed(date)) {
-                    this.date = null
-                    this.dateFormatted = ''
                 }
                 return
             }

--- a/src/components/form/AzDate.vue
+++ b/src/components/form/AzDate.vue
@@ -241,6 +241,9 @@ export default {
                     this.date = null
                     this.dateFormatted = ''
                     this.$emit('input', null)
+                } else if (this.dateMaxIsAllowed(date) || this.dateMinIsAllowed(date)) {
+                    this.date = null
+                    this.dateFormatted = ''
                 }
                 return
             }
@@ -458,8 +461,8 @@ export default {
             if (this.minDate) {
                 const dateObj = this.getDayMonthYearFromDateString(date)
                 const minDateObj = this.getDayMonthYearFromDateString(this.moment(this.minDate).format('DD/MM/YYYY'))
-                return this.moment(`${dateObj.year}-${dateObj.month}-${dateObj.day}`)
-                    .isBefore(`${minDateObj.year}-${minDateObj.month}-${minDateObj.day}`)
+                return this.moment(this.moment(`${dateObj.year}-${dateObj.month}-${dateObj.day}`))
+                    .isBefore(this.moment(`${minDateObj.year}-${minDateObj.month}-${minDateObj.day}`))
             }
             return false
         },
@@ -468,7 +471,7 @@ export default {
                 const dateObj = this.getDayMonthYearFromDateString(date)
                 const maxDateObj = this.getDayMonthYearFromDateString(this.moment(this.maxDate).format('DD/MM/YYYY'))
                 return this.moment(`${dateObj.year}-${dateObj.month}-${dateObj.day}`)
-                    .isAfter(`${maxDateObj.year}-${maxDateObj.month}-${maxDateObj.day}`)
+                    .isAfter(this.moment(`${maxDateObj.year}-${maxDateObj.month}-${maxDateObj.day}`))
             }
             return false
         },


### PR DESCRIPTION
When date is before min-date or after max-date, az-date shoul be set date to empty, when user insert date by keyboard