### PR TITLE
Changes on AzPdfDocumentViewer and AzDigitalSignature components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azinformatica/loki",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Biblioteca de componentes visuais compartilhados construidos usando vuejs.",
   "main": "src/index.js",
   "private": false,

--- a/src/components/viewer/AzPdfDocumentViewer.spec.js
+++ b/src/components/viewer/AzPdfDocumentViewer.spec.js
@@ -288,7 +288,7 @@ describe('AzPdfDocumentViewer.spec.js', () => {
             expect(wrapper.vm.pdf.viewer.currentScaleValue).toEqual('page-fit')
         })
 
-        it('Should execute changeScaleType method when has not a default value', () => {
+        it('Should execute changeScaleType method when has any value', () => {
             wrapper = shallowMount(AzPdfDocumentViewer, {
                 localVue,
                 propsData: { src, httpHeader, downloadButton },

--- a/src/components/viewer/AzPdfDocumentViewer.spec.js
+++ b/src/components/viewer/AzPdfDocumentViewer.spec.js
@@ -265,12 +265,12 @@ describe('AzPdfDocumentViewer.spec.js', () => {
             expect(wrapper.vm.pdf.viewer.currentScale).toEqual(0.2)
         })
 
-        it('Should execute resetZoom method', () => {
+        it('Should execute changeScaleType method when has a default value', () => {
             wrapper = shallowMount(AzPdfDocumentViewer, {
                 localVue,
                 propsData: { src, httpHeader, downloadButton },
                 stubs: {
-                    Toolbar: '<button @click=\'$emit("resetZoom")\' ></button>'
+                    Toolbar: '<button @click=\'$emit("changeScaleType")\' ></button>'
                 }
             })
             wrapper.setData({
@@ -285,7 +285,31 @@ describe('AzPdfDocumentViewer.spec.js', () => {
             })
             wrapper.find('button').trigger('click')
 
-            expect(wrapper.vm.pdf.viewer.currentScale).toEqual(1)
+            expect(wrapper.vm.pdf.viewer.currentScaleValue).toEqual('page-fit')
+        })
+
+        it('Should execute changeScaleType method when has not a default value', () => {
+            wrapper = shallowMount(AzPdfDocumentViewer, {
+                localVue,
+                propsData: { src, httpHeader, downloadButton },
+                stubs: {
+                    Toolbar: '<button @click=\'$emit("changeScaleType")\' ></button>'
+                }
+            })
+            wrapper.setData({
+                scale: {
+                    default: 1,
+                    type: 'page-fit'
+                },
+                pdf: {
+                    viewer: {
+                        currentScale: 3
+                    }
+                }
+            })
+            wrapper.find('button').trigger('click')
+
+            expect(wrapper.vm.pdf.viewer.currentScaleValue).toEqual('page-width')
         })
     })
 

--- a/src/components/viewer/AzPdfDocumentViewer.vue
+++ b/src/components/viewer/AzPdfDocumentViewer.vue
@@ -182,7 +182,6 @@ export default {
         defaultScaleType: {
             type: String,
             default: ''
-            // values: 'page-width', 'page-fit'
         }
     },
     computed: {

--- a/src/components/viewer/AzPdfDocumentViewer.vue
+++ b/src/components/viewer/AzPdfDocumentViewer.vue
@@ -70,7 +70,7 @@ export default {
         },
         scaleChangeEventHandler(e) {
             this.scale.current = e.scale
-            this.scale.type = e.presetValue
+            if (e.presetValue) this.scale.type = e.presetValue
         },
         pageChangeEventHandler(e) {
             this.pagination.current = e.pageNumber

--- a/src/components/viewer/AzPdfDocumentViewer.vue
+++ b/src/components/viewer/AzPdfDocumentViewer.vue
@@ -209,7 +209,7 @@ export default {
         scale: {
             default: null,
             current: null,
-            type: null
+            type: ''
         }
     })
 }

--- a/src/components/viewer/Toolbar.spec.js
+++ b/src/components/viewer/Toolbar.spec.js
@@ -71,15 +71,15 @@ describe('Toolbar.spec.js', () => {
             expect(zoomInBtn).toBeTruthy()
         })
 
-        it('Should have a resetZoom button', () => {
-            const resetZoomBtn = wrapper.find('[data-test="resetZoom"]')
-            expect(resetZoomBtn).toBeTruthy()
+        it('Should have a changeScaleType button', () => {
+            const changeScaleType = wrapper.find('[data-test="changeScaleType"]')
+            expect(changeScaleType).toBeTruthy()
         })
 
         it('Should disable the buttons', () => {
             expect(wrapper.find('[data-test="zoomOut"]').html()).toContain('disabled="true"')
             expect(wrapper.find('[data-test="zoomIn"]').html()).toContain('disabled="true"')
-            expect(wrapper.find('[data-test="resetZoom"]').html()).toContain('disabled="true"')
+            expect(wrapper.find('[data-test="changeScaleType"]').html()).toContain('disabled="true"')
             expect(wrapper.find('[data-test="download"]').html()).toContain('disabled="true"')
         })
     })
@@ -97,10 +97,10 @@ describe('Toolbar.spec.js', () => {
             expect(wrapper.emitted().zoomIn).toBeTruthy()
         })
 
-        it('Should emit an event on click at resetZoom button', () => {
-            let resetZoomBtn = wrapper.find('[data-test="resetZoom"]')
-            resetZoomBtn.vm.$emit('click')
-            expect(wrapper.emitted().resetZoom).toBeTruthy()
+        it('Should emit an event on click at changeScaleType button', () => {
+            let changeScaleTypeBtn = wrapper.find('[data-test="changeScaleType"]')
+            changeScaleTypeBtn.vm.$emit('click')
+            expect(wrapper.emitted().changeScaleType).toBeTruthy()
         })
     })
 })

--- a/src/components/viewer/Toolbar.vue
+++ b/src/components/viewer/Toolbar.vue
@@ -5,8 +5,14 @@
         <v-btn class="az-pdf-toolbar__content" @click="$emit('zoomOut')" icon data-test="zoomOut" :disabled="disableButtons">
             <v-icon>zoom_out</v-icon>
         </v-btn>
-        <v-btn class="az-pdf-toolbar__content" @click="$emit('resetZoom')" icon data-test="resetZoom" :disabled="disableButtons">
-            <v-icon>aspect_ratio</v-icon>
+        <v-btn class="az-pdf-toolbar__content" @click="$emit('changeScaleType')" icon data-test="changeScaleType" :disabled="disableButtons">
+            <v-tooltip bottom>
+                <span v-if="scaleType === 'page-fit'" >Ajustar à largura</span>
+                <span v-if="scaleType === 'page-width'" >Ajustar à altura</span>
+
+                <v-icon v-if="scaleType === 'page-fit'" slot="activator" >fullscreen</v-icon>
+                <v-icon v-if="scaleType === 'page-width'" slot="activator" >fullscreen_exit</v-icon>
+            </v-tooltip>
         </v-btn>
         <v-btn class="az-pdf-toolbar__content" @click="$emit('zoomIn')" icon data-test="zoomIn" :disabled="disableButtons">
             <v-icon>zoom_in</v-icon>
@@ -43,6 +49,10 @@ export default {
         pagination: {
             type: Object,
             default: () => ({ current: '-', total: '-' })
+        },
+        scaleType: {
+            type: String,
+            required: true
         }
     }
 }

--- a/src/components/viewer/Toolbar.vue
+++ b/src/components/viewer/Toolbar.vue
@@ -3,10 +3,13 @@
     <v-toolbar class="az-pdf-toolbar" flat>
         <v-spacer />
         <v-btn class="az-pdf-toolbar__content" @click="$emit('zoomOut')" icon data-test="zoomOut" :disabled="disableButtons">
-            <v-icon>zoom_out</v-icon>
+            <v-tooltip bottom open-delay="800">
+                <span>Zoom -</span>
+                <v-icon slot="activator" >zoom_out</v-icon>
+            </v-tooltip>
         </v-btn>
         <v-btn class="az-pdf-toolbar__content" @click="$emit('changeScaleType')" icon data-test="changeScaleType" :disabled="disableButtons">
-            <v-tooltip bottom>
+            <v-tooltip bottom open-delay="800">
                 <span v-if="scaleType === 'page-fit'" >Ajustar à largura</span>
                 <span v-if="scaleType === 'page-width'" >Ajustar à altura</span>
 
@@ -15,7 +18,10 @@
             </v-tooltip>
         </v-btn>
         <v-btn class="az-pdf-toolbar__content" @click="$emit('zoomIn')" icon data-test="zoomIn" :disabled="disableButtons">
-            <v-icon>zoom_in</v-icon>
+            <v-tooltip bottom open-delay="800">
+                <span>Zoom +</span>
+                <v-icon slot="activator" >zoom_in</v-icon>
+            </v-tooltip>
         </v-btn>
         <div class="az-pdf-toolbar__pagination" data-test="pagination">
             {{ pagination.current || '-' }} / {{ pagination.total || '-' }}
@@ -29,7 +35,10 @@
             data-test="download"
             :disabled="disableButtons"
         >
-            <v-icon>get_app</v-icon>
+            <v-tooltip bottom open-delay="800">
+                <span>Download</span>
+                <v-icon slot="activator" >get_app</v-icon>
+            </v-tooltip>
         </v-btn>
     </v-toolbar>
 </template>

--- a/src/utils/AzDigitalSignature.js
+++ b/src/utils/AzDigitalSignature.js
@@ -76,7 +76,7 @@ export default class AzDigitalSignature {
             algoritmo: paramsToSign.algoritmoHash
         })
 
-        await this._finishSign(documentId, signHash, paramsToSign, rubricBase64)
+        return await this._finishSign(documentId, signHash, paramsToSign, rubricBase64)
     }
 
     /**
@@ -88,7 +88,7 @@ export default class AzDigitalSignature {
     }
 
     async _finishSign(documentId, signHash, paramsToSign, rubricBase64) {
-        await this.store.dispatch(actionTypes.SIGNATURE.DIGITAL.FINISH, {
+        return await this.store.dispatch(actionTypes.SIGNATURE.DIGITAL.FINISH, {
             documentId: documentId,
             signHash: signHash,
             temporarySubscription: paramsToSign.assinaturaTemporariaId,


### PR DESCRIPTION
### AzPdfDocumentViewer

- The action buttons on the toolbar won a tooltip.

- Added a property ''defaultScaleType" to set a default scale  type on load documents. The possible values are ```page-width``` and ```page-fit```(default).

- Changed the central action button to switch between scale  types quoted above.

### AzDigitalSignature

- The sign method returns the API response when the digital signature is complete.