### PR TITLE
New feature and console warning fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azinformatica/loki",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Biblioteca de componentes visuais compartilhados construidos usando vuejs.",
   "main": "src/index.js",
   "private": false,

--- a/src/components/layout/AzAvatar.spec.js
+++ b/src/components/layout/AzAvatar.spec.js
@@ -9,9 +9,11 @@ Vue.use(Vuetify)
 localVue.use(Vuex)
 
 describe('AzAvatar.spec.js', () => {
-    let wrapper, store
+    let wrapper, store, azAuth
 
     beforeEach(() => {
+        azAuth = jest.fn()
+
         store = new Vuex.Store({
             state: {
                 loki: {
@@ -29,7 +31,13 @@ describe('AzAvatar.spec.js', () => {
             }
         })
 
-        wrapper = mount(AzAvatar, { localVue, store })
+        wrapper = mount(AzAvatar, {
+            localVue,
+            store,
+            directives: {
+                azAuth
+            }
+        })
     })
 
     it('Computed properties are rendered properly', () => {

--- a/src/components/layout/AzLogo.spec.js
+++ b/src/components/layout/AzLogo.spec.js
@@ -9,9 +9,13 @@ Vue.use(Vuetify)
 Vue.use(Vuex)
 
 describe('AzLogo.spec.js', () => {
-    let wrapper, store
+    let wrapper, store, $router
 
     beforeEach(() => {
+        $router = {
+            push: jest.fn()
+        }
+
         store = new Vuex.Store({
             state: {
                 loki: {
@@ -26,7 +30,13 @@ describe('AzLogo.spec.js', () => {
             }
         })
 
-        wrapper = shallowMount(AzLogo, { localVue, store })
+        wrapper = shallowMount(AzLogo, {
+            localVue,
+            store,
+            mocks: {
+                $router
+            }
+        })
     })
 
     it('Computed properties are rendered properly', () => {

--- a/src/components/viewer/AzPdfDocumentViewer.spec.js
+++ b/src/components/viewer/AzPdfDocumentViewer.spec.js
@@ -212,7 +212,7 @@ describe('AzPdfDocumentViewer.spec.js', () => {
                 localVue,
                 propsData: { src, httpHeader, downloadButton },
                 stubs: {
-                    Toolbar: '<button @click=\'$emit("zoomIn")\' ></button>'
+                    Toolbar: { template: '<button @click=\'$emit("zoomIn")\' ></button>' }
                 }
             })
             wrapper.setData({
@@ -235,7 +235,7 @@ describe('AzPdfDocumentViewer.spec.js', () => {
                 localVue,
                 propsData: { src, httpHeader, downloadButton },
                 stubs: {
-                    Toolbar: '<button @click=\'$emit("zoomOut")\' ></button>'
+                    Toolbar: { template: '<button @click=\'$emit("zoomOut")\' ></button>' }
                 }
             })
             wrapper.setData({
@@ -258,7 +258,7 @@ describe('AzPdfDocumentViewer.spec.js', () => {
                 localVue,
                 propsData: { src, httpHeader, downloadButton },
                 stubs: {
-                    Toolbar: '<button @click=\'$emit("zoomOut")\' ></button>'
+                    Toolbar: { template: '<button @click=\'$emit("zoomOut")\' ></button>' }
                 }
             })
             wrapper.setData({
@@ -281,7 +281,7 @@ describe('AzPdfDocumentViewer.spec.js', () => {
                 localVue,
                 propsData: { src, httpHeader, downloadButton },
                 stubs: {
-                    Toolbar: '<button @click=\'$emit("changeScaleType")\' ></button>'
+                    Toolbar: { template: '<button @click=\'$emit("changeScaleType")\' ></button>' }
                 }
             })
             wrapper.setData({
@@ -304,7 +304,7 @@ describe('AzPdfDocumentViewer.spec.js', () => {
                 localVue,
                 propsData: { src, httpHeader, downloadButton },
                 stubs: {
-                    Toolbar: '<button @click=\'$emit("changeScaleType")\' ></button>'
+                    Toolbar: { template: '<button @click=\'$emit("changeScaleType")\' ></button>' }
                 }
             })
             wrapper.setData({
@@ -328,7 +328,7 @@ describe('AzPdfDocumentViewer.spec.js', () => {
                 localVue,
                 propsData: { src, httpHeader, downloadButton },
                 stubs: {
-                    Toolbar: '<button @click=\'$emit("rotate")\' ></button>'
+                    Toolbar: { template: '<button @click=\'$emit("rotate")\' ></button>' }
                 }
             })
             wrapper.setData({
@@ -350,7 +350,7 @@ describe('AzPdfDocumentViewer.spec.js', () => {
                 localVue,
                 propsData: { src, httpHeader, downloadButton },
                 stubs: {
-                    Toolbar: '<button @click=\'$emit("download")\' ></button>'
+                    Toolbar: { template: '<button @click=\'$emit("download")\' ></button>' }
                 }
             })
             wrapper.find('button').trigger('click')

--- a/src/components/viewer/AzPdfDocumentViewer.spec.js
+++ b/src/components/viewer/AzPdfDocumentViewer.spec.js
@@ -37,17 +37,24 @@ Vue.use(Vuetify)
 Vue.use(Vuex)
 
 describe('AzPdfDocumentViewer.spec.js', () => {
-    let src, httpHeader, downloadButton, progressBar, wrapper
+    let src, httpHeader, downloadButton, progressBar, rotateButton, wrapper
 
     beforeEach(() => {
         src = 'document/url'
         httpHeader = { token: '123abcd456' }
         downloadButton = true
         progressBar = true
+        rotateButton = true
 
         wrapper = shallowMount(AzPdfDocumentViewer, {
             localVue,
-            propsData: { src, httpHeader, downloadButton, progressBar },
+            propsData: {
+                src,
+                httpHeader,
+                downloadButton,
+                progressBar,
+                rotateButton
+            },
             attachTo: document.body
         })
     })
@@ -76,6 +83,10 @@ describe('AzPdfDocumentViewer.spec.js', () => {
 
         it('Should receive props progressBar', () => {
             expect(wrapper.props().progressBar).toBeTruthy()
+        })
+
+        it('Should receive props rotateButton', () => {
+            expect(wrapper.props().rotateButton).toBeTruthy()
         })
     })
 
@@ -310,6 +321,26 @@ describe('AzPdfDocumentViewer.spec.js', () => {
             wrapper.find('button').trigger('click')
 
             expect(wrapper.vm.pdf.viewer.currentScaleValue).toEqual('page-width')
+        })
+
+        it('Should execute rotate method', () => {
+            wrapper = shallowMount(AzPdfDocumentViewer, {
+                localVue,
+                propsData: { src, httpHeader, downloadButton },
+                stubs: {
+                    Toolbar: '<button @click=\'$emit("rotate")\' ></button>'
+                }
+            })
+            wrapper.setData({
+                pdf: {
+                    viewer: {
+                        pagesRotation: 0
+                    }
+                }
+            })
+            wrapper.find('button').trigger('click')
+
+            expect(wrapper.vm.pdf.viewer.pagesRotation).toEqual(90)
         })
     })
 

--- a/src/components/viewer/AzPdfDocumentViewer.vue
+++ b/src/components/viewer/AzPdfDocumentViewer.vue
@@ -4,6 +4,7 @@
             :disableButtons="!src"
             :downloadButton="downloadButton"
             :pagination="pagination"
+            :rotateButton="rotateButton"
             :scaleType="scale.type"
             @changeScaleType="changeScaleType"
             @zoomIn="zoomIn"
@@ -186,6 +187,10 @@ export default {
         defaultScaleType: {
             type: String,
             default: ''
+        },
+        rotateButton: {
+            type: Boolean,
+            default: false
         }
     },
     computed: {

--- a/src/components/viewer/AzPdfDocumentViewer.vue
+++ b/src/components/viewer/AzPdfDocumentViewer.vue
@@ -8,6 +8,7 @@
             @changeScaleType="changeScaleType"
             @zoomIn="zoomIn"
             @zoomOut="zoomOut"
+            @rotate="rotate"
             @download="download"
             v-show="!loadingPlaceHolder"
         />
@@ -143,6 +144,9 @@ export default {
             if (this.scale.current > 0.2) {
                 this.pdf.viewer.currentScale = this.scale.current / 1.1
             }
+        },
+        rotate() {
+            this.pdf.viewer.pagesRotation = this.pdf.viewer.pagesRotation + 90
         },
         download() {
             this.$emit('download')

--- a/src/components/viewer/Toolbar.spec.js
+++ b/src/components/viewer/Toolbar.spec.js
@@ -7,7 +7,7 @@ const localVue = createLocalVue()
 Vue.use(Vuetify)
 
 describe('Toolbar.spec.js', () => {
-    let disableButtons, downloadButton, pagination, wrapper
+    let disableButtons, downloadButton, pagination, rotateButton, scaleType, wrapper
 
     beforeEach(() => {
         disableButtons = true
@@ -16,12 +16,16 @@ describe('Toolbar.spec.js', () => {
             current: 1,
             total: 3
         }
+        rotateButton = true
+        scaleType = 'page-fit'
         wrapper = shallowMount(Toolbar, {
             localVue,
             propsData: {
                 disableButtons,
                 downloadButton,
-                pagination
+                pagination,
+                rotateButton,
+                scaleType
             }
         })
     })
@@ -32,7 +36,7 @@ describe('Toolbar.spec.js', () => {
         })
 
         it('Should have a default value to pagination', () => {
-            wrapper = shallowMount(Toolbar, { localVue })
+            wrapper = shallowMount(Toolbar, { localVue, propsData: { scaleType } })
             expect(wrapper.props().pagination).toEqual({ current: '-', total: '-' })
         })
 
@@ -41,17 +45,26 @@ describe('Toolbar.spec.js', () => {
         })
 
         it('Should have a default value to disableButtons', () => {
-            wrapper = shallowMount(Toolbar, { localVue })
+            wrapper = shallowMount(Toolbar, { localVue, propsData: { scaleType } })
             expect(wrapper.props().disableButtons).toBeFalsy()
         })
 
         it('Should receive a downloadButton', () => {
-            expect(wrapper.props().pagination).toBeTruthy()
+            expect(wrapper.props().downloadButton).toBeTruthy()
         })
 
         it('Should have a default value to downloadButton', () => {
-            wrapper = shallowMount(Toolbar, { localVue })
+            wrapper = shallowMount(Toolbar, { localVue, propsData: { scaleType } })
             expect(wrapper.props().downloadButton).toBeFalsy()
+        })
+
+        it('Should receive a rotateButton', () => {
+            expect(wrapper.props().rotateButton).toBeTruthy()
+        })
+
+        it('Should have a default value to rotateButton', () => {
+            wrapper = shallowMount(Toolbar, { localVue, propsData: { scaleType } })
+            expect(wrapper.props().rotateButton).toBeFalsy()
         })
     })
 
@@ -71,9 +84,28 @@ describe('Toolbar.spec.js', () => {
             expect(zoomInBtn).toBeTruthy()
         })
 
+        it('Should have a download button', () => {
+            let downloadBtn = wrapper.find('[data-test="download"]')
+            expect(downloadBtn).toBeTruthy()
+        })
+
+        it('Should have a rotate button', () => {
+            let rotateBtn = wrapper.find('[data-test="rotate"]')
+            expect(rotateBtn).toBeTruthy()
+        })
+
         it('Should have a changeScaleType button', () => {
-            const changeScaleType = wrapper.find('[data-test="changeScaleType"]')
-            expect(changeScaleType).toBeTruthy()
+            let changeScaleType = wrapper.find('[data-test="changeScaleType"]')
+            expect(changeScaleType.html()).toContain('fullscreen')
+
+            wrapper = shallowMount(Toolbar, {
+                localVue,
+                propsData: {
+                    scaleType: 'page-width'
+                }
+            })
+            changeScaleType = wrapper.find('[data-test="changeScaleType"]')
+            expect(changeScaleType.html()).toContain('fullscreen_exit')
         })
 
         it('Should disable the buttons', () => {
@@ -81,6 +113,7 @@ describe('Toolbar.spec.js', () => {
             expect(wrapper.find('[data-test="zoomIn"]').html()).toContain('disabled="true"')
             expect(wrapper.find('[data-test="changeScaleType"]').html()).toContain('disabled="true"')
             expect(wrapper.find('[data-test="download"]').html()).toContain('disabled="true"')
+            expect(wrapper.find('[data-test="rotate"]').html()).toContain('disabled="true"')
         })
     })
 
@@ -101,6 +134,18 @@ describe('Toolbar.spec.js', () => {
             let changeScaleTypeBtn = wrapper.find('[data-test="changeScaleType"]')
             changeScaleTypeBtn.vm.$emit('click')
             expect(wrapper.emitted().changeScaleType).toBeTruthy()
+        })
+
+        it('Should emit an event on click at download button', () => {
+            let downloadBtn = wrapper.find('[data-test="download"]')
+            downloadBtn.vm.$emit('click')
+            expect(wrapper.emitted().download).toBeTruthy()
+        })
+
+        it('Should emit an event on click at rotate button', () => {
+            let rotateBtn = wrapper.find('[data-test="rotate"]')
+            rotateBtn.vm.$emit('click')
+            expect(wrapper.emitted().rotate).toBeTruthy()
         })
     })
 })

--- a/src/components/viewer/Toolbar.vue
+++ b/src/components/viewer/Toolbar.vue
@@ -27,7 +27,14 @@
             {{ pagination.current || '-' }} / {{ pagination.total || '-' }}
         </div>
         <v-spacer />
-        <v-btn class="az-pdf-toolbar__content" @click="$emit('rotate')" icon data-test="rotate" :disabled="disableButtons">
+        <v-btn 
+            class="az-pdf-toolbar__content"
+            @click="$emit('rotate')"
+            v-if="rotateButton"
+            icon
+            data-test="rotate"
+            :disabled="disableButtons"
+        >
             <v-tooltip bottom open-delay="800">
                 <span>Rotacionar</span>
                 <v-icon slot="activator">rotate_right</v-icon>
@@ -64,6 +71,10 @@ export default {
         pagination: {
             type: Object,
             default: () => ({ current: '-', total: '-' })
+        },
+        rotateButton: {
+            type: Boolean,
+            default: false
         },
         scaleType: {
             type: String,

--- a/src/components/viewer/Toolbar.vue
+++ b/src/components/viewer/Toolbar.vue
@@ -78,7 +78,7 @@ export default {
         },
         scaleType: {
             type: String,
-            required: true
+            default: 'page-fit'
         }
     }
 }

--- a/src/components/viewer/Toolbar.vue
+++ b/src/components/viewer/Toolbar.vue
@@ -27,6 +27,12 @@
             {{ pagination.current || '-' }} / {{ pagination.total || '-' }}
         </div>
         <v-spacer />
+        <v-btn class="az-pdf-toolbar__content" @click="$emit('rotate')" icon data-test="rotate" :disabled="disableButtons">
+            <v-tooltip bottom open-delay="800">
+                <span>Rotacionar</span>
+                <v-icon slot="activator">rotate_right</v-icon>
+            </v-tooltip>
+        </v-btn>
         <v-btn
             class="az-pdf-toolbar__content"
             @click="$emit('download')"


### PR DESCRIPTION
### AzPdfDocumentViewer

- added 'rotate' funcionality, that can be activated through ```rotateButton``` props.
- resolve the deprecation warn at stubs attribute

### AzAvatar

- mocks the az-auth directive to resolve warnings on unit tests

### AzLogo

- mocks the $router.push method to resolve warnings on unit tests