### PR TITLE
Bugfix - wrong resize event when 'defaultScaleType' prop is defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azinformatica/loki",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Biblioteca de componentes visuais compartilhados construidos usando vuejs.",
   "main": "src/index.js",
   "private": false,

--- a/src/components/viewer/AzPdfDocumentViewer.vue
+++ b/src/components/viewer/AzPdfDocumentViewer.vue
@@ -73,7 +73,7 @@ export default {
         },
         pagesInitEventHandler(e) {
             this.setInitialPagination(e.source)
-            this.updateScaleType(this.defaultScaleType)
+            this.updateScaleType()
             this.setInitialScale(e.source)
         },
         scaleChangeEventHandler(e) {
@@ -119,7 +119,9 @@ export default {
             if (scaleType && typeof scaleType === 'string') {
                 this.pdf.viewer.currentScaleValue = scaleType
             } else {
-                if (this.isSmallScreen()) {
+                if (this.defaultScaleType && typeof this.defaultScaleType === 'string') {
+                    this.pdf.viewer.currentScaleValue = this.defaultScaleType
+                } else if (this.isSmallScreen()) {
                     this.pdf.viewer.currentScaleValue = 'page-width'
                 } else {
                     this.pdf.viewer.currentScaleValue = 'page-fit'

--- a/src/components/viewer/Toolbar.vue
+++ b/src/components/viewer/Toolbar.vue
@@ -36,7 +36,7 @@
             :disabled="disableButtons"
         >
             <v-tooltip bottom open-delay="800">
-                <span>Rotacionar</span>
+                <span>Girar</span>
                 <v-icon slot="activator">rotate_right</v-icon>
             </v-tooltip>
         </v-btn>


### PR DESCRIPTION
### AzPdfDocumentViewer

- fix the resize event when component has defaultScaleType prop defined
- change in the rotate button tooltip