### PR TITLE
Atualizando prop depreciada no AzAside

### DIFF
--- a/src/components/layout/AzAside.vue
+++ b/src/components/layout/AzAside.vue
@@ -3,7 +3,7 @@
         app
         :mini-variant.sync="asideClosed"
         v-model="drawer"
-        mobile-break-point="720"
+        mobile-breakpoint="720"
         mini-variant-width="60"
         :width="width"
         class="az-aside primary"


### PR DESCRIPTION
Atualizado a prop "mobile-break-point" no componente AzAside, a mesma estava depreciada e isso causava um bug no menu lateral em uma determinada resolução da tela, fazendo com que o menu lateral não fique acessível.