### PR TITLE
Adicionando o prop 'OrderBy' no AzComboEnum

### DIFF
--- a/src/components/form/AzComboEnum.vue
+++ b/src/components/form/AzComboEnum.vue
@@ -38,6 +38,10 @@ export default {
             type: Object,
             required: true
         },
+        orderBy: {
+            type: String,
+            default: 'text'
+        },
         label: {
             type: String,
             default: ''
@@ -97,7 +101,7 @@ export default {
                 for (let [chave, valor] of Object.entries(objeto)) {
                     novoArray.push({ text: valor, value: chave })
                 }
-                novoArray = _.sortBy(novoArray, 'text')
+                novoArray = _.sortBy(novoArray, this.orderBy)
             }
             if (this.insertNullItem) {
                 return _.union([{ text: 'Selecione', value: null }], novoArray)


### PR DESCRIPTION
Adicionado o prop 'OrderBy' para definir o atributo de ordenação do select, visto que a ordenação do Lodash utilizada no trecho "novoArray = _.sortBy(novoArray, 'text')" ordena pelo texto comum do objeto enumerado. Foi identificado que essa ordenação não considera acentuação, então ela perde a capacidade de ordenar corretamente em casos de palavras que comecem com acentuação (Exemplo: Álcool), fazendo com que o item vá para o último lugar da lista. O prop 'OrderBy' vai possibilitar que seja definido a ordenação pela chave (value) do objeto enumerado, corrigindo assim a ordenação, visto que a chave geralmente não possui acentuação.