### PR TITLE
Remove caracteres especiais do telefone antes de aplicar formatação.

### DIFF
--- a/src/filters/az-phone.js
+++ b/src/filters/az-phone.js
@@ -1,10 +1,10 @@
 import StringMask from 'string-mask'
 
 const filter = phone => {
+    if (!phone) return 'Não informado'
+
     phone = phone.replace(/\D+/g, '')
-    if (!phone) {
-        return 'Não informado'
-    }
+
     if (phone.length < 11) {
         return new StringMask('(##) ####-####').apply(phone)
     } else {

--- a/src/filters/az-phone.js
+++ b/src/filters/az-phone.js
@@ -1,6 +1,7 @@
 import StringMask from 'string-mask'
 
 const filter = phone => {
+    phone = phone.replace(/\D+/g, '')
     if (!phone) {
         return 'Não informado'
     }


### PR DESCRIPTION
Caso o filtro seja usado em uma string que contenha um telefone já formatado, além de não realizar a "formatação" o telefone acaba sendo exibido de forma errada.