### PR TITLE
Retirado obrigatoriedade do router no loki.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,9 +74,6 @@ const lokiPlugin = {
         if (!store) {
             throw new Error('Please provide vuex store.')
         }
-        if (!router) {
-            throw new Error('Please provide router.')
-        }
 
         store.registerModule('loki', { state, mutations, actions, getters })
         Vue.component('az-title', AzTitle)
@@ -126,11 +123,14 @@ const lokiPlugin = {
         Vue.filter('azPhone', azPhone)
         Vue.filter('azTitleCase', azTitleCase)
 
-        store.commit(mutationTypes.SET_MENU_ACTIONS, buildMenu(store, router))
+        if (router) {
+            store.commit(mutationTypes.SET_MENU_ACTIONS,
+              buildMenu(store, router))
 
-        router.afterEach(to => {
-            store.commit(mutationTypes.SET_CURRENT_PAGE, to)
-        })
+            router.afterEach(to => {
+                store.commit(mutationTypes.SET_CURRENT_PAGE, to)
+            })
+        }
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -124,8 +124,7 @@ const lokiPlugin = {
         Vue.filter('azTitleCase', azTitleCase)
 
         if (router) {
-            store.commit(mutationTypes.SET_MENU_ACTIONS,
-              buildMenu(store, router))
+            store.commit(mutationTypes.SET_MENU_ACTIONS, buildMenu(store, router))
 
             router.afterEach(to => {
                 store.commit(mutationTypes.SET_CURRENT_PAGE, to)


### PR DESCRIPTION
Devido a uma nova funcionalidade no sistema de patrimônio mobiliário, foi necessário realizar o tratamento de rotas feito no loki dentro de nosso sistema, com isso foi necessário retirar a obrigatoriedade do parâmetro de router do loki para evitar processamento desnecessário.