### PR TITLE
[CHANGE]: Melhorias no component AzMoney

### DIFF
--- a/src/components/form/AzMoney.vue
+++ b/src/components/form/AzMoney.vue
@@ -19,13 +19,13 @@
         @keydown="checkKeyAndValidate($event)"
         @keyup="checkKey($event)"
     >
-        <template v-if="$slots['label']">
+        <template v-slot:label v-if="$slots['label']">
             <slot name="label" />
         </template>
-        <template v-if="$slots['append-outer']">
+        <template v-slot:append-outer v-if="$slots['append-outer']">
             <slot name="append-outer" />
         </template>
-        <template v-if="$slots['append']">
+        <template v-slot:append v-if="$slots['append']">
             <slot name="append" />
         </template>
     </v-text-field>

--- a/src/components/form/AzMoney.vue
+++ b/src/components/form/AzMoney.vue
@@ -158,7 +158,9 @@ export default {
         },
         cleanValue() {
             this.$emit('input', null)
-            this.$emit(this.eventSubmit, null)
+            if (this.eventSubmit) {
+                this.$emit(this.eventSubmit, null)
+            }
             this.clickedField = false
         },
         createRules() {
@@ -211,7 +213,7 @@ export default {
                     this.$emit('input', valueNumber)
                 }
 
-                if (this.eventSubmit === event) {
+                if (!this.eventSubmit || this.eventSubmit === event) {
                     this.$emit(event, valueNumber)
                     this.clickedField = false
                 }


### PR DESCRIPTION
1. Mudanças
- Agora o `vee-validate` é utilizado para validar a obrigatoriedade do campo. Deste forma, você pode utilizar a função `validateAll()` para aplicar sua regra de negócio;
- Houve uma mudança no comportamento da props `maxLength`. Antes não era permitido alterar o campo quando o `maxLength` era atingido, e em alguns momentos não era possível aplicar o sinal de negativo e reajustar os valores do campo. Agora, utilizando junto ao `vee-validate`,  `maxLength` é usado para validar a **quantidade de dígitos numéricos** caso a props `validateLength` seja informada;
- Algumas props foram descontinuadas;
- O valor default  do `maxLength` foi alterado de **24 para 15**. Vale ressaltar que valores maiores que [MAX_SAFE_INTEGER](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) podem gerar problemas de precisão;
- A props `showClearButton` hablita o `clearable` do `v-text-field`;
- Acrescentamos a props `dense`;
- Acrescentamos o disparo de evento `change`;
- O disparo do evento `input` agora é disparado sempre que o valor informado no campo é diferente da props `value`, independente da props `eventSubmit` ter sido informada ou não;
- Agora ao limpar o campo, são disparados os eventos de `input` e `eventSubmit`;
- A reatividade do component foi mantida